### PR TITLE
fix: improve RAG benchmark quality (spoiler safety + grounding)

### DIFF
--- a/backend/boom/core/graph.py
+++ b/backend/boom/core/graph.py
@@ -19,7 +19,7 @@ from anthropic import Anthropic
 from langgraph.graph import StateGraph, END
 
 from boom import config
-from .prompts import SYSTEM_PROMPTS, SANITIZE_PROMPT, CITATION_INSTRUCTIONS, EVALUATE_PROMPT
+from .prompts import SYSTEM_PROMPTS, EVALUATE_PROMPT
 from .vector_store import VectorStore, SearchResult, reciprocal_rank_fusion
 
 logger = logging.getLogger(__name__)
@@ -31,10 +31,10 @@ VALID_TYPES = {"vocabulary", "context", "lookup", "analysis"}
 LOG_SEPARATOR = "──────────────────────────────────────────────"
 
 TOKEN_LIMITS = {
-    "vocabulary": 512,
-    "context": 1024,
-    "lookup": 1024,
-    "analysis": 2048,
+    "vocabulary": 256,
+    "context": 512,
+    "lookup": 512,
+    "analysis": 1024,
 }
 
 
@@ -420,9 +420,7 @@ def _write_readable_log(state: QAState, log_entry: dict):
         sanitize_count = state.get("sanitize_ahead_count", 0)
         if sanitize_count:
             section("Sanitization")
-            f.write(f"\n  Model:    {config.CLAUDE_HAIKU_MODEL}\n")
-            f.write(f"  AHEAD chunks sanitized: {sanitize_count}\n")
-            f.write(f"  Tokens:   {state.get('sanitize_tokens_in', 0)} in / {state.get('sanitize_tokens_out', 0)} out\n")
+            f.write(f"\n  AHEAD chunks dropped: {sanitize_count}\n")
 
         # LLM Input
         sys_prompt = state.get("gen_system_prompt") or ""
@@ -586,7 +584,11 @@ def build_qa_graph(anthropic: Anthropic, vector_store: VectorStore, voyage_clien
         classify_prompt = (
             f'Question: "{question}"\n'
             f'Selected text: "{selected[:200]}"\n\n'
-            f"Classify as exactly one of: vocabulary, context, lookup, analysis\n"
+            f"Classify as exactly one of:\n"
+            f"- vocabulary: The selected text IS the word/phrase to define\n"
+            f"- context: Reader wants to understand a specific passage they selected\n"
+            f"- lookup: Reader wants factual info from elsewhere in the book\n"
+            f"- analysis: Reader wants literary interpretation or thematic discussion\n\n"
             f"Extract key entities (names, terms, concepts).\n\n"
             f'Return: {{"type": "...", "entities": [...]}}'
         )
@@ -884,7 +886,7 @@ def build_qa_graph(anthropic: Anthropic, vector_store: VectorStore, voyage_clien
             logger.info("── RERANK (disabled, applying adaptive cutoff only) %s", LOG_SEPARATOR[50:])
             for c in chunks:
                 if c["label"] == "AHEAD":
-                    c["score"] *= 0.5
+                    c["score"] *= 0.3
             chunks.sort(key=lambda c: c["score"], reverse=True)
             cutoff = _adaptive_cutoff(chunks)
             logger.info("  Output: %d chunks", len(cutoff))
@@ -912,7 +914,7 @@ def build_qa_graph(anthropic: Anthropic, vector_store: VectorStore, voyage_clien
         # Penalize AHEAD chunks to reduce spoiler exposure
         for c in reranked:
             if c["label"] == "AHEAD":
-                c["score"] *= 0.5
+                c["score"] *= 0.3
         reranked.sort(key=lambda c: c["score"], reverse=True)
 
         reranked = _adaptive_cutoff(reranked)
@@ -955,7 +957,7 @@ def build_qa_graph(anthropic: Anthropic, vector_store: VectorStore, voyage_clien
     # --- Node: sanitize ---
 
     async def sanitize_node(state: QAState) -> dict:
-        """Replace AHEAD chunk text with spoiler-safe summaries via Haiku."""
+        """Drop AHEAD chunks to prevent spoiler leakage."""
         chunks = state.get("chunks", [])
         ahead = [c for c in chunks if c["label"] == "AHEAD"]
 
@@ -964,53 +966,18 @@ def build_qa_graph(anthropic: Anthropic, vector_store: VectorStore, voyage_clien
             return {}
 
         logger.info("── SANITIZE %s", LOG_SEPARATOR[12:])
-        logger.info("  AHEAD chunks to sanitize: %d", len(ahead))
+        logger.info("  Dropping %d AHEAD chunks (spoiler prevention)", len(ahead))
 
-        passages = "\n===\n".join(c["text"] for c in ahead)
-        user_prompt = f"Summarize each passage below. One summary per passage, separated by ===.\n\n{passages}"
+        past_only = [c for c in chunks if c["label"] == "PAST"]
 
-        try:
-            response = anthropic.messages.create(
-                model=config.CLAUDE_HAIKU_MODEL,
-                max_tokens=1024,
-                system=SANITIZE_PROMPT,
-                messages=[{"role": "user", "content": user_prompt}],
-            )
-            raw = response.content[0].text.strip()
-            summaries = [s.strip() for s in raw.split("===")]
-            tokens_in = response.usage.input_tokens
-            tokens_out = response.usage.output_tokens
-
-            logger.info("  Tokens: %d in / %d out", tokens_in, tokens_out)
-
-            # Match summaries to AHEAD chunks
-            for i, chunk in enumerate(ahead):
-                if i < len(summaries) and summaries[i]:
-                    chunk["text"] = summaries[i]
-                    logger.info("  [%d] chunk %d → %s", i + 1, chunk["chunk_index"], summaries[i][:100])
-                else:
-                    chunk["text"] = "This passage continues the narrative."
-                    logger.info("  [%d] chunk %d → (fallback)", i + 1, chunk["chunk_index"])
-
-        except Exception as e:
-            logger.warning("  Sanitization failed: %s — using fallback text", e)
-            tokens_in = 0
-            tokens_out = 0
-            for chunk in ahead:
-                chunk["text"] = "This passage continues the narrative."
-
-        # Reassemble: PAST unchanged + sanitized AHEAD
-        past = [c for c in chunks if c["label"] == "PAST"]
-        sanitized = past + ahead
-
-        logger.info("  Result: %d PAST + %d sanitized AHEAD = %d chunks", len(past), len(ahead), len(sanitized))
+        logger.info("  Result: %d PAST chunks kept, %d AHEAD dropped", len(past_only), len(ahead))
         logger.info(LOG_SEPARATOR)
 
         return {
-            "chunks": sanitized,
+            "chunks": past_only,
             "sanitize_ahead_count": len(ahead),
-            "sanitize_tokens_in": tokens_in,
-            "sanitize_tokens_out": tokens_out,
+            "sanitize_tokens_in": 0,
+            "sanitize_tokens_out": 0,
         }
 
     # --- Node: generate ---

--- a/backend/boom/core/prompts.py
+++ b/backend/boom/core/prompts.py
@@ -4,15 +4,23 @@ Type-specific system prompts for the LangGraph RAG pipeline.
 Each question type gets a tailored prompt that shapes the response style.
 """
 
+GROUNDING_RULE = """
+CRITICAL GROUNDING RULE:
+- Base your answer ONLY on the provided context passages and selected text.
+- Do NOT use your own knowledge of this book, its plot, characters, or themes beyond what appears in the passages below.
+- If the context doesn't contain enough information, say so. Do not guess or fill in from memory.
+"""
+
 STYLE_INSTRUCTIONS = """
 Style rules:
 - Be direct and concise. No filler, no fluff, no dramatic narration.
 - Answer the question, then stop. Don't recap what the reader already knows.
 - Never summarize the plot so far or narrate the reader's journey ("You started by...", "You've seen him...").
 - Short paragraphs. Prefer 2-4 sentences over a wall of text.
+- Keep responses under 150 words for simple questions, under 300 for analysis.
 - Address the reader as "you." Never say "the user" or "the reader.\""""
 
-POSITION_INSTRUCTIONS = """
+POSITION_INSTRUCTIONS = GROUNDING_RULE + """
 The reader is at a specific point in the book. You know things they don't yet.
 
 [ALREADY READ] — Content before the reader's position. Use freely in your answer.
@@ -28,24 +36,6 @@ Rules for [COMING UP] content:
 
 These passages were retrieved automatically — never say "the source you provided" or "the passage you gave me." Refer to them as "the book" or "the text.\""""
 
-SANITIZE_PROMPT = """You are a spoiler-prevention content filter. Your job is to replace book passages with spoiler-safe topical summaries.
-
-You will receive passages from a book that the reader has NOT yet reached. These passages were retrieved by a search system and will be shown to an AI assistant answering the reader's question.
-
-CRITICAL RULES — violations cause real harm to the reading experience:
-- NEVER reveal what happens in any passage: no events, outcomes, twists, revelations, deaths, betrayals, discoveries, or resolutions.
-- NEVER mention specific dialogue, actions, decisions, or emotional reactions of characters.
-- NEVER hint at character fates, relationship changes, or plot developments.
-- NEVER reference locations, times, or circumstances that would reveal plot progression.
-- NEVER preserve proper nouns that only appear in future content — they are spoilers by existence.
-
-WHAT TO OUTPUT:
-- For each passage, write ONE sentence describing the topic/theme WITHOUT revealing content.
-- Use only: character names already known, general themes (trust, identity, deception, family), and narrative elements (narration style, tone, perspective).
-- Format: "This passage involves [character] and touches on themes of [theme]."
-- If you cannot summarize safely, write: "This passage continues the narrative."
-
-You will receive passages separated by ===. Return exactly one summary line per passage, separated by ===."""
 
 EVALUATE_PROMPT = """You are a quality evaluator for a reading assistant. Score the answer on two dimensions:
 

--- a/backend/boom/core/vector_store.py
+++ b/backend/boom/core/vector_store.py
@@ -344,8 +344,25 @@ class VectorStore:
             if start_idx <= e.chunk.metadata['chunk_index'] <= end_idx
         ]
 
+    @staticmethod
+    def _normalize_quotes(text: str) -> str:
+        """Normalize smart quotes, dashes, and whitespace to ASCII equivalents."""
+        replacements = {
+            '\u2018': "'", '\u2019': "'",  # smart single quotes
+            '\u201c': '"', '\u201d': '"',  # smart double quotes
+            '\u2014': '--', '\u2013': '-',  # em/en dashes
+            '\u2026': '...',               # ellipsis
+        }
+        for src, dst in replacements.items():
+            text = text.replace(src, dst)
+        return re.sub(r'\s+', ' ', text).strip()
+
     async def find_chunk_containing(self, book_id: str, text: str) -> int:
-        """Find the chunk index that contains the given text."""
+        """Find the chunk index that contains the given text.
+
+        Uses progressive matching: tries full text, then 200, 100, 50 char
+        snippets with normalized quotes and case-insensitive comparison.
+        """
         entries = self.entries.get(book_id)
         if not entries:
             entries = await self.load_from_file(book_id)
@@ -353,12 +370,29 @@ class VectorStore:
                 self.entries[book_id] = entries
         if not entries or not text:
             return 0
-        # Normalize whitespace to match chunker output
-        normalized = re.sub(r'\s+', ' ', text).strip()
-        snippet = normalized[:50]
-        for entry in entries:
-            if snippet in entry.chunk.text:
-                return entry.chunk.metadata['chunk_index']
+
+        normalized = self._normalize_quotes(text)
+
+        # Precompute normalized chunk texts once
+        normalized_chunks = [
+            (self._normalize_quotes(e.chunk.text).lower(), e.chunk.metadata['chunk_index'])
+            for e in entries
+        ]
+
+        # Progressive snippet lengths — try longest first for best accuracy
+        # Deduplicate and skip lengths longer than the text
+        snippet_lengths = list(dict.fromkeys(
+            l for l in [len(normalized), 200, 100, 50] if l <= len(normalized)
+        ))
+
+        for length in snippet_lengths:
+            snippet = normalized[:length].lower()
+            if not snippet:
+                continue
+            for chunk_text, chunk_index in normalized_chunks:
+                if snippet in chunk_text:
+                    return chunk_index
+
         return 0
 
     async def keyword_search(self, book_id: str, text: str) -> list[SearchResult]:


### PR DESCRIPTION
## Summary

Benchmark scores for Gone Girl are 1.6/3 overall with 0/15 clean cases. Root causes: parametric knowledge spoiler leaks, retrieval misses (9/15), fabrication, and verbosity.

### Fix 1: Grounding Rule (highest impact)
The legacy `rag.py` had a grounding rule ("Base your answer ONLY on the provided context...") but it was never ported to `prompts.py` which the LangGraph pipeline uses. Added `GROUNDING_RULE` constant and prepended it to `POSITION_INSTRUCTIONS`. Fixes both spoiler leakage and fabrication — same root cause (parametric knowledge).

### Fix 2: Drop AHEAD Chunks Instead of Sanitizing (high impact)
The sanitize node was calling Haiku to summarize AHEAD chunks, but even summaries triggered parametric recall (caused the `gg-diary-shove-fabricated` regression). Replaced with simple AHEAD chunk removal. Also increased the AHEAD rerank penalty from 0.5 → 0.3 in both the rerank-enabled and rerank-disabled code paths. Saves a Haiku API call per query.

### Fix 3: Improve `find_chunk_containing()` (medium impact)
Previous implementation checked only first 50 chars with no quote normalization, causing 9/15 retrieval misses in the benchmark. Now uses:
- Smart quote/dash normalization to ASCII equivalents
- Progressive matching: tries full text, then 200, 100, 50 char snippets
- Case-insensitive comparison
- Precomputed normalized chunk texts to avoid repeated work in nested loops

### Fix 4: Tighten Token Limits + Word Budget (medium impact)
Cut all `TOKEN_LIMITS` in half (vocabulary 512→256, context/lookup 1024→512, analysis 2048→1024). Added word budget guideline to `STYLE_INSTRUCTIONS`: under 150 words for simple questions, under 300 for analysis.

### Fix 5: Classifier Type Definitions (low impact)
Added brief definitions to the classifier prompt to distinguish vocabulary vs context vs lookup vs analysis — the most common confusion was vocabulary vs lookup.

### Cleanup
- Removed dead `SANITIZE_PROMPT` constant from `prompts.py` (no longer used after sanitize rewrite)
- Removed dead `SANITIZE_PROMPT` and `CITATION_INSTRUCTIONS` imports from `graph.py`
- Updated readable log section to say "AHEAD chunks dropped" instead of referencing Haiku model/tokens

## Test plan

- [ ] Run `cd backend && python -m benchmarks.run --book gone-girl`
- [ ] Compare with baseline `.data/benchmarks/20260222-010822/report.md`
- [ ] Target: overall ≥2.0/3, spoiler safety ≥2.0/3, ≥3 clean cases