### PR TITLE
fix: require selected_text in readthrough question gen, add repair heuristic and grounding nudge

### DIFF
--- a/backend/badger/core/agent.py
+++ b/backend/badger/core/agent.py
@@ -662,6 +662,18 @@ async def run_agent(
             else:
                 messages.append({"role": "assistant", "content": "I was unable to find relevant passages."})
                 messages.append({"role": "user", "content": no_context_msg})
+        elif not selected_text:
+            grounding_msg = (
+                "IMPORTANT: No specific passage was highlighted for this question. "
+                "Only state information that literally appears in the provided sources. "
+                "If the sources don't contain the answer, tell the reader you couldn't find the relevant passage."
+            )
+            last = messages[-1]
+            if last["role"] == "user" and isinstance(last["content"], str):
+                messages[-1] = {"role": "user", "content": last["content"] + "\n\n" + grounding_msg}
+            else:
+                messages.append({"role": "assistant", "content": "I have retrieved some passages."})
+                messages.append({"role": "user", "content": grounding_msg})
 
         # Max turns reached or no-context injected — get final answer
         response = await asyncio.to_thread(
@@ -834,6 +846,18 @@ async def run_agent_streaming(
         else:
             messages.append({"role": "assistant", "content": "I was unable to find relevant passages."})
             messages.append({"role": "user", "content": no_context_msg})
+    elif all_chunks and not selected_text and not final_response:
+        grounding_msg = (
+            "IMPORTANT: No specific passage was highlighted for this question. "
+            "Only state information that literally appears in the provided sources. "
+            "If the sources don't contain the answer, tell the reader you couldn't find the relevant passage."
+        )
+        last = messages[-1]
+        if last["role"] == "user" and isinstance(last["content"], str):
+            messages[-1] = {"role": "user", "content": last["content"] + "\n\n" + grounding_msg}
+        else:
+            messages.append({"role": "assistant", "content": "I have retrieved some passages."})
+            messages.append({"role": "user", "content": grounding_msg})
 
     # Phase 2: Streaming answer
     sources = [

--- a/backend/reader/prompts.py
+++ b/backend/reader/prompts.py
@@ -108,7 +108,10 @@ Question type guidelines based on your position ({position:.0%}):
 For each question, provide:
 - "question": the question text (natural, conversational)
 - "selected_text": an EXACT substring from the section text above that \
-triggered this question. Must be a verbatim copy of text from the section.
+triggered this question. Must be a verbatim copy of text from the section. \
+REQUIRED (must not be empty) for question_type "vocabulary", "lookup", and \
+"context" — these types need an anchor passage to retrieve the right content. \
+Copy the specific word, phrase, name, or sentence that prompted the question.
 - "question_type": one of "vocabulary", "context", "lookup", "analysis"
 - "motivation": why the reader would ask this (1 sentence)
 - "expected_answer": a sketch of what a good answer would include (2-3 sentences)
@@ -120,6 +123,21 @@ and quoting specific passages from the book (vocabulary definitions, factual \
 lookups, locating a specific scene). false if the question requires \
 interpretation, thematic synthesis, character motivation analysis, or \
 connecting ideas across multiple sections. When in doubt, prefer false.
+
+Examples of correctly filled selected_text:
+
+vocabulary example — the foreign word itself must be copied:
+{{"question": "What does 'mujahid' mean?", "selected_text": "mujahid", \
+"question_type": "vocabulary", "motivation": "Unfamiliar Arabic term.", \
+"expected_answer": "A Muslim fighter in a holy war.", "triggered_by": null, \
+"answerable_by_retrieval": true}}
+
+lookup example — the name or concept phrase must be copied:
+{{"question": "Who is Professor Lovell and why does Letty trust him?", \
+"selected_text": "Professor Lovell", "question_type": "lookup", \
+"motivation": "Lovell appears suddenly and Letty defers to him completely.", \
+"expected_answer": "Lovell is a senior Oxford professor who recruited Robin.", \
+"triggered_by": null, "answerable_by_retrieval": true}}
 
 Return a JSON array of question objects. Return ONLY valid JSON.\
 """

--- a/backend/reader/questions.py
+++ b/backend/reader/questions.py
@@ -23,6 +23,69 @@ def _normalize_ws(text: str) -> str:
     return re.sub(r'\s+', ' ', text).strip()
 
 
+def _repair_selected_text(question: str, recent_text: str) -> str:
+    """Attempt to extract a ~120-char anchor window from recent_text for a question.
+
+    Tries candidates in priority order:
+      1. Quoted phrases (any quote marks including smart quotes)
+      2. Words with non-ASCII characters (diacritics, CJK) — foreign terms
+      3. Multi-word capitalized sequences (proper names)
+      4. Single capitalized words that aren't sentence-initial
+
+    For the first candidate found in recent_text, returns a ~120-char window
+    centered on the match snapped to word boundaries. Returns empty string if
+    no candidate matches.
+    """
+    candidates: list[str] = []
+
+    # 1. Quoted phrases
+    for m in re.finditer(r'[\u201c\u2018\u0022\u0027]([^\u201d\u2019\u0022\u0027]{2,60})[\u201d\u2019\u0022\u0027]', question):
+        candidates.append(m.group(1).strip())
+
+    # 2. Words with non-ASCII characters
+    for m in re.finditer(r'\b\w*[^\x00-\x7F]\w*\b', question):
+        candidates.append(m.group(0))
+
+    # 3. Multi-word capitalized sequences (2+ consecutive title-case words)
+    for m in re.finditer(r'\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\b', question):
+        candidates.append(m.group(1))
+
+    # 4. Single capitalized words that aren't sentence-initial (preceded by non-period)
+    for m in re.finditer(r'(?<=[a-z,;:]\s)([A-Z][a-z]{2,})\b', question):
+        candidates.append(m.group(1))
+
+    for candidate in candidates:
+        # Case-sensitive search first, then case-insensitive fallback
+        idx = recent_text.find(candidate)
+        if idx == -1:
+            lower_text = recent_text.lower()
+            lower_candidate = candidate.lower()
+            idx = lower_text.find(lower_candidate)
+        if idx == -1:
+            continue
+
+        # Build ~120-char window centered on match, snapped to word boundaries
+        half = 60
+        start = max(0, idx - half)
+        end = min(len(recent_text), idx + len(candidate) + half)
+
+        # Snap start forward to next word boundary
+        if start > 0:
+            space = recent_text.find(' ', start)
+            if space != -1 and space < idx:
+                start = space + 1
+
+        # Snap end back to previous word boundary
+        if end < len(recent_text):
+            space = recent_text.rfind(' ', idx + len(candidate), end)
+            if space != -1:
+                end = space
+
+        return recent_text[start:end].strip()
+
+    return ""
+
+
 @dataclass
 class GeneratedQuestion:
     question: str
@@ -115,6 +178,10 @@ async def generate_questions(
     normalized_text = _normalize_ws(recent_text)
 
     questions: list[GeneratedQuestion] = []
+    total_answerable = 0
+    has_anchor = 0
+    repaired = 0
+
     for q in parsed[:max_questions]:
         if not isinstance(q, dict):
             continue
@@ -136,12 +203,24 @@ async def generate_questions(
                 logger.warning("  Hallucinated selected_text for question: %s", question_text[:60])
                 selected = ""
 
+        # Repair missing selected_text for retrieval-anchor types
+        if not selected and qtype in ("vocabulary", "lookup", "context"):
+            repaired_text = _repair_selected_text(question_text, recent_text)
+            if repaired_text:
+                selected = repaired_text
+                repaired += 1
+
         # Determine if this question can be answered by passage retrieval
         raw_answerable = q.get("answerable_by_retrieval")
         if isinstance(raw_answerable, bool):
             answerable = raw_answerable
         else:
             answerable = qtype in ("vocabulary", "lookup")
+
+        if answerable:
+            total_answerable += 1
+            if selected:
+                has_anchor += 1
 
         questions.append(GeneratedQuestion(
             question=question_text,
@@ -154,4 +233,6 @@ async def generate_questions(
         ))
 
     logger.info("  Generated %d valid questions (of %d returned)", len(questions), len(parsed))
+    logger.info("  selected_text: %d/%d answerable questions have anchors (%d repaired)",
+                has_anchor, total_answerable, repaired)
     return questions, usage

--- a/backend/reader/reader.py
+++ b/backend/reader/reader.py
@@ -544,6 +544,10 @@ async def run_readthrough(
                     stop_follow_ups += 1
                     total_follow_ups += 1
 
+                    if q.selected_text:
+                        logger.info("  Follow-up inherits selected_text from q%d: %s",
+                                    q_idx, (q.selected_text or "")[:60])
+
                     if answer_mode in ("direct", "direct_fallback"):
                         # Follow-up also uses direct path
                         fu_answer, fu_direct_usage = await direct_answer(


### PR DESCRIPTION
## Summary

Fixes #47 — the readthrough question generator omits `selected_text` for 68% of answerable questions, causing blind retrieval that returns wrong chunks and drives confabulation.

- **`reader/prompts.py`** — Mark `selected_text` as REQUIRED for vocabulary/lookup/context types with two few-shot examples
- **`reader/questions.py`** — Add `_repair_selected_text()` that extracts quoted phrases, foreign words, and proper names from the question, finds them in the chapter text, and returns a ~120-char anchor window. Wired into `generate_questions()` with miss-rate logging
- **`badger/core/agent.py`** — Inject grounding nudge when chunks exist but no `selected_text` anchor was provided (both streaming and non-streaming paths)
- **`reader/reader.py`** — Log when follow-ups inherit parent's `selected_text`

## Test plan

- [x] All 221 existing tests pass
- [ ] Run short readthrough and check `selected_text:` log line for improved anchor rate
- [ ] Verify vocabulary/lookup questions consistently have `selected_text` populated
- [ ] Confirm grounding nudge fires for anchorless queries (check agent logs)
- [ ] Verify follow-up inheritance log appears when parent has `selected_text`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic text anchor extraction for retrieval-answerable questions, improving question grounding from source material.
  * Enhanced passage retrieval handling when passages are returned but specific text selections are unavailable.

* **Documentation**
  * Clarified question generation instructions with examples for required text selections.

* **Improvements**
  * Added detailed logging for retrieval-based follow-up generation tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->